### PR TITLE
[6.1.1] Fix Tooltips on ContextualToolbar

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Releases]
 
+## [6.1.1] - 2025-12-22
+### Fixed
+- Tooltips were not appearing on ContextualToolbar due to Angular rendering issues with libraries.
+
 ## [6.1.0] - 2025-01-15
 ### Added
 - New event emitter in FabSpeedDial to notify when the state of the component is changed.

--- a/projects/comat/package.json
+++ b/projects/comat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cotecna/material",
-  "version": "6.1.0",
+  "version": "6.1.1-beta.1",
   "author": "Cotecna",
   "license": "MIT",
   "publishConfig": {

--- a/projects/comat/package.json
+++ b/projects/comat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cotecna/material",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1",
   "author": "Cotecna",
   "license": "MIT",
   "publishConfig": {

--- a/projects/comat/src/lib/contextual-toolbar/contextual-toolbar.component.html
+++ b/projects/comat/src/lib/contextual-toolbar/contextual-toolbar.component.html
@@ -12,9 +12,9 @@
     <button mat-icon-button 
             *ngFor="let action of actions" 
             (click)="actionSelected(action)"
-            [class.textButton]="showButtonText()">
-      <mat-icon [matTooltip]="action.tooltip ? action.tooltip : action.name"
-                *ngIf="showButtonIcon()">{{action.icon}}</mat-icon>
+            [class.textButton]="showButtonText()"
+            [matTooltip]="action.tooltip ? action.tooltip : action.name">
+      <mat-icon *ngIf="showButtonIcon()">{{action.icon}}</mat-icon>
       <span *ngIf="showButtonText()">{{action.text}}</span>
     </button>
     


### PR DESCRIPTION
Tooltips were not appearing on ContextualToolbar due to Angular rendering issues with libraries.